### PR TITLE
fix: secure Google Chat transport, paths, and OAuth state

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Splunk, 2024-2025
+   Copyright (c) Splunk, 2024-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,2 @@
-Splunk SOAR Google Chat App
-Copyright (c) Splunk, 2024
-
-Third-party Software Attributions:
+Splunk SOAR App: Google Chat App
+Copyright (c) Splunk, 2024-2026

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **client_secret** | required | password | Auth application Client Secret |
 **code** | required | password | Code to receive authorization token. Read README.md on how to obtain this |
 **redirect_uri** | required | string | Redirect URL for authorization |
+**verify_server_cert** | optional | boolean | Verify TLS certificates for Google API requests |
 
 ### Supported Actions
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Google Chat App
 
-Publisher: Splunk Community \
-Connector Version: 1.0.1 \
-Product Vendor: Google Cloud \
-Product Name: Google Chat App \
+Publisher: Splunk Community <br>
+Connector Version: 1.0.1 <br>
+Product Vendor: Google Cloud <br>
+Product Name: Google Chat App <br>
 Minimum Product Version: 6.1.1.211
 
 This app integrate services with Google Chat and manage Chat resources such as i.e messages. Remmeber that user will need authentication code, check Github or SplunkBase for information on how to obtain it
@@ -37,15 +37,15 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[create message](#action-create-message) - Creates a message in a Google Chat space \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[create message](#action-create-message) - Creates a message in a Google Chat space <br>
 [read message](#action-read-message) - Returns details about a message
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -60,7 +60,7 @@ No Output
 
 Creates a message in a Google Chat space
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -91,7 +91,7 @@ summary.total_objects_successful | numeric | | |
 
 Returns details about a message
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -123,7 +123,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 
-# Copyright (c) Splunk, 2024-2025
+# Copyright (c) Splunk, 2024-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googlechatapp.json
+++ b/googlechatapp.json
@@ -48,6 +48,12 @@
             "required": true,
             "default": "http://localhost",
             "order": 3
+        },
+        "verify_server_cert": {
+            "description": "Verify TLS certificates for Google API requests",
+            "data_type": "boolean",
+            "default": true,
+            "order": 4
         }
     },
     "actions": [

--- a/googlechatapp.json
+++ b/googlechatapp.json
@@ -7,7 +7,7 @@
     "logo": "logo_googlechatapp.svg",
     "logo_dark": "logo_googlechatapp_dark.svg",
     "product_name": "Google Chat App",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk Community",
     "contributors": [
@@ -15,7 +15,7 @@
             "name": "Patryk Dros"
         }
     ],
-    "license": "Copyright (c) Splunk, 2024-2025",
+    "license": "Copyright (c) Splunk, 2024-2026",
     "app_version": "1.0.1",
     "utctime_updated": "2024-04-16T15:27:25.341827Z",
     "package_name": "phantom_googlechatapp",
@@ -229,5 +229,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/googlechatapp_connector.py
+++ b/googlechatapp_connector.py
@@ -20,6 +20,7 @@ import json
 import re
 
 # Phantom App imports
+import encryption_helper
 import phantom.app as phantom
 import requests
 from bs4 import BeautifulSoup
@@ -149,16 +150,13 @@ class GoogleChatAppConnector(BaseConnector):
         return self._process_response(r, action_result)
 
     def encode_token(self, token):
-        sample_string_bytes = token.encode("ascii")
-        base64_bytes = base64.b64encode(sample_string_bytes)
-        base64_string = base64_bytes.decode("ascii")
-        return base64_string
+        return encryption_helper.encrypt(token, self.get_asset_id())
 
-    def decode_token(self, token_base64):
-        base64_bytes = token_base64.encode("ascii")
-        sample_string_bytes = base64.b64decode(base64_bytes)
-        sample_string = sample_string_bytes.decode("ascii")
-        return sample_string
+    def decode_token(self, stored_token):
+        try:
+            return encryption_helper.decrypt(stored_token, self.get_asset_id())
+        except Exception:
+            return base64.b64decode(stored_token.encode("ascii"), validate=True).decode("ascii")
 
     def _generate_new_access_token(self, action_result, grant_type='"authorization_code"'):
         """This function is used to generate new access token using the code obtained on authorization."""
@@ -193,7 +191,8 @@ class GoogleChatAppConnector(BaseConnector):
         self._state["access_token"] = self.encode_token(resp_json["access_token"])
         if grant_type != "refresh_token":
             self._refresh_token = resp_json.get("refresh_token")
-            self._state["refresh_token"] = self.encode_token(resp_json["refresh_token"])
+            if self._refresh_token:
+                self._state["refresh_token"] = self.encode_token(self._refresh_token)
 
         return phantom.APP_SUCCESS
 
@@ -327,9 +326,24 @@ class GoogleChatAppConnector(BaseConnector):
             self.debug_print("Resetting the state file with the default format")
             self._state = {"app_version": self.get_app_json().get("app_version")}
         else:
-            if self._state.get("refresh_token"):
-                self._refresh_token = self.decode_token(self._state["refresh_token"])
-            else:
+            for token_name in ("access_token", "refresh_token"):
+                stored_token = self._state.get(token_name)
+                if not stored_token:
+                    continue
+                try:
+                    token = self.decode_token(stored_token)
+                except Exception as e:
+                    self.debug_print(f"Unable to decrypt {token_name}: {e!s}")
+                    self._state.pop(token_name, None)
+                    continue
+                if not stored_token.startswith("iv:"):
+                    self._state[token_name] = self.encode_token(token)
+                if token_name == "access_token":
+                    self._access_token = token
+                else:
+                    self._refresh_token = token
+
+            if not self._refresh_token:
                 self.save_progress(
                     "There is not Refresh token inside the state file, make sure you are runinng test connectivity action \
                                  or do it at first before further app exploration."

--- a/googlechatapp_connector.py
+++ b/googlechatapp_connector.py
@@ -1,6 +1,6 @@
 # File: googlechatapp_connector.py
 
-# Copyright (c) Splunk, 2024-2025
+# Copyright (c) Splunk, 2024-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/googlechatapp_connector.py
+++ b/googlechatapp_connector.py
@@ -17,6 +17,7 @@
 
 import base64
 import json
+import re
 
 # Phantom App imports
 import phantom.app as phantom
@@ -222,6 +223,10 @@ class GoogleChatAppConnector(BaseConnector):
         # Add an action result object to self (BaseConnector) to represent the action for this param
         action_result = self.add_action_result(ActionResult(dict(param)))
 
+        parent = param["parent_space"]
+        if not re.fullmatch(r"spaces/[^/?#]+", parent):
+            return action_result.set_status(phantom.APP_ERROR, "Parent space must match spaces/{space}")
+
         gen_ret_val = self._generate_new_access_token(action_result, grant_type="refresh_token")
         if phantom.is_fail(gen_ret_val):
             # the call to the 3rd party device or service failed, action result should contain all the error details
@@ -231,7 +236,6 @@ class GoogleChatAppConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        parent = param["parent_space"]
         json_content = {"text": param["text_message"]}
 
         # Optional values should use the .get() function
@@ -267,6 +271,10 @@ class GoogleChatAppConnector(BaseConnector):
         # Add an action result object to self (BaseConnector) to represent the action for this param
         action_result = self.add_action_result(ActionResult(dict(param)))
 
+        name = param["name"]
+        if not re.fullmatch(r"spaces/[^/?#]+/messages/[^/?#]+", name):
+            return action_result.set_status(phantom.APP_ERROR, "Message name must match spaces/{space}/messages/{message}")
+
         gen_ret_val = self._generate_new_access_token(action_result, grant_type="refresh_token")
         if phantom.is_fail(gen_ret_val):
             # the call to the 3rd party device or service failed, action result should contain all the error details
@@ -276,7 +284,6 @@ class GoogleChatAppConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        name = param["name"]
         url = self._base_url + f"/v1/{name}"
 
         headers = {"Authorization": "Bearer " + self._access_token, "Content-Type": "application/json; charset=utf-8"}

--- a/googlechatapp_connector.py
+++ b/googlechatapp_connector.py
@@ -139,7 +139,7 @@ class GoogleChatAppConnector(BaseConnector):
             r = request_func(
                 url,
                 # auth=(username, password),  # basic authentication
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
                 **kwargs,
             )
         except Exception as e:

--- a/googlechatapp_consts.py
+++ b/googlechatapp_consts.py
@@ -1,6 +1,6 @@
 # File: googlechatapp_consts.py
 
-# Copyright (c) Splunk, 2024-2025
+# Copyright (c) Splunk, 2024-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * - Verify TLS server certificates by default for Google API requests.
 * - Validate Google Chat resource names before including them in API paths.
+* - Encrypt OAuth access and refresh tokens stored in connector state.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Verify TLS server certificates by default for Google API requests.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,5 +1,5 @@
 **Unreleased**
 
-* - Verify TLS server certificates by default for Google API requests.
-* - Validate Google Chat resource names before including them in API paths.
-* - Encrypt OAuth access and refresh tokens stored in connector state.
+* Verify TLS server certificates by default for Google API requests.
+* Validate Google Chat resource names before including them in API paths.
+* Encrypt OAuth access and refresh tokens stored in connector state.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Verify TLS server certificates by default for Google API requests.
+* - Validate Google Chat resource names before including them in API paths.


### PR DESCRIPTION
## Summary

- verify Google API TLS certificates by default
- validate space and message resource names before building request paths
- encrypt OAuth tokens in connector state
- migrate existing base64-encoded token state on first load
- refresh the Python 3.9/3.13 quality baseline

## Tracking

- [PAPP-38189](https://splunk.atlassian.net/browse/PAPP-38189)
- [PSAAS-31152](https://splunk.atlassian.net/browse/PSAAS-31152)
- [PSAAS-31163](https://splunk.atlassian.net/browse/PSAAS-31163)
- [PSAAS-31393](https://splunk.atlassian.net/browse/PSAAS-31393)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Validation

- full pre-commit suite passed outside the sandbox
- Docker-backed dependency packaging passed
- static tests, app linter, Ruff, Semgrep, and secret scanning passed
- hosted pre-commit and compile are required before marking ready

This pull request was authored by Codex with AI assistance.

## Tracking

- PAPP: PAPP-38189
- PSAAS: PSAAS-31152, PSAAS-31163, PSAAS-31393
- Written by Codex.